### PR TITLE
Change memoized method to not accept a block

### DIFF
--- a/spec/unit/memoizable/method_builder/call_spec.rb
+++ b/spec/unit/memoizable/method_builder/call_spec.rb
@@ -47,6 +47,14 @@ describe Memoizable::MethodBuilder, '#call' do
       subject
       expect(descendant.new.send(method_name)).to be_frozen
     end
+
+    it 'creates a method that does not accept a block' do
+      subject
+      expect { descendant.new.send(method_name) {} }.to raise_error(
+        described_class::BlockNotAllowedError,
+        "Cannot pass a block to #{descendant}##{method_name}, it is memoized"
+      )
+    end
   end
 
   context 'public method' do

--- a/spec/unit/memoizable/module_methods/memoize_spec.rb
+++ b/spec/unit/memoizable/module_methods/memoize_spec.rb
@@ -10,7 +10,7 @@ shared_examples_for 'memoizes method' do
     expect(instance.send(method)).to be(instance.send(method))
   end
 
-  it 'creates a method with an arity of 0' do
+  it 'creates a zero arity method', :unless => RUBY_VERSION == '1.8.7' do
     subject
     expect(object.new.method(method).arity).to be_zero
   end


### PR DESCRIPTION
This branch changes the memoized method to not accept a block.

Originally in #6 we discussed using `block_given?` but it does not behave as expected within `define_block`. I changed it to yield `|&block|` which allows me to test `block` and raise an exception if a block was passed.

The only downside with this approach is that under `1.8.7` the new memoized method changes it's arity to `1`. The method arity is correctly reported as `0` for 1.9.3+. I added a guard clause to skip this test under 1.8.7, but if anyone can think of an approach that allows the arity to remain `0` under 1.8.7 please let me know.
