### PR TITLE
Update version of thread_safe to ~> 0.2.0

### DIFF
--- a/memoizable.gemspec
+++ b/memoizable.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files       = Dir.glob('spec/{unit,integration}/**/*.rb')
   gem.extra_rdoc_files = Dir.glob('**/*.md')
 
-  gem.add_runtime_dependency('thread_safe', '~> 0.1.3')
+  gem.add_runtime_dependency('thread_safe', '~> 0.2.0')
 
   gem.add_development_dependency('bundler', '~> 1.3', '>= 1.3.5')
 end


### PR DESCRIPTION
Updating to the latest version.

Using it with Rails 4.0.3 brings conflicts

```
rails (= 4.0.3) ruby depends on
      thread_safe (0.2.0)
```
