### PR TITLE
upgrade thread_safe to concurrent-ruby?

### DIFF
--- a/lib/memoizable.rb
+++ b/lib/memoizable.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 require 'monitor'
-require 'thread_safe'
+require 'concurrent/map'
 
 require 'memoizable/instance_methods'
 require 'memoizable/method_builder'

--- a/lib/memoizable/memory.rb
+++ b/lib/memoizable/memory.rb
@@ -13,7 +13,7 @@ module Memoizable
     #
     # @api private
     def initialize
-      @memory  = ThreadSafe::Cache.new
+      @memory  = Concurrent::Map.new
       @monitor = Monitor.new
       freeze
     end

--- a/memoizable.gemspec
+++ b/memoizable.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files            = %w[CONTRIBUTING.md LICENSE.md README.md memoizable.gemspec] + Dir['lib/**/*.rb']
   gem.extra_rdoc_files = Dir['**/*.md']
 
-  gem.add_runtime_dependency('thread_safe', '~> 0.3', '>= 0.3.4')
+  gem.add_runtime_dependency('concurrent-ruby', '~> 1.0', '>= 1.0.4')
 
   gem.add_development_dependency('bundler', '~> 1.7', '>= 1.7.9')
 end


### PR DESCRIPTION
[headius/thread_safe](https://github.com/headius/thread_safe/blob/master/README.md) was merged into https://github.com/ruby-concurrency/concurrent-ruby and is no longer maintained.

This makes use of the new `Concurrent::Map`, replacing `ThreadSafe::Cache`