### PR TITLE
Add `#delete` and `#clear`

### DIFF
--- a/config/mutant.yml
+++ b/config/mutant.yml
@@ -1,4 +1,5 @@
 ---
+usage: opensource
 integration:
   name: rspec
 requires:

--- a/lib/memoizable/memory.rb
+++ b/lib/memoizable/memory.rb
@@ -85,6 +85,40 @@ module Memoizable
       end
     end
 
+    # Remove all values from memory
+    #
+    # @example
+    #   memory = Memoizable::Memory.new(foo: 1)
+    #   memory.clear
+    #
+    # @return [void]
+    #
+    # @api public
+    def clear
+      @monitor.synchronize do
+        @memory.clear
+        nil
+      end
+    end
+
+    # Remove a specific value from memory
+    #
+    # @example
+    #   memory = Memoizable::Memory.new(foo: 1)
+    #   memory.delete(:foo)
+    #
+    # @param [Symbol] name
+    #
+    # @return [void]
+    #
+    # @api public
+    def delete(name)
+      @monitor.synchronize do
+        @memory.delete(name)
+        nil
+      end
+    end
+
     # A hook that allows Marshal to dump the object
     #
     # @example

--- a/spec/unit/memoizable/memory/clear_spec.rb
+++ b/spec/unit/memoizable/memory/clear_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Memoizable::Memory, '#clear' do
   subject { described_class.new(foo: 1) }
 
-  it 'returns itself' do
+  it 'returns nil' do
     expect(subject.clear).to be_nil
   end
 

--- a/spec/unit/memoizable/memory/clear_spec.rb
+++ b/spec/unit/memoizable/memory/clear_spec.rb
@@ -11,4 +11,18 @@ describe Memoizable::Memory, '#clear' do
     subject.clear
     expect { subject[:foo] }.to raise_error(NameError)
   end
+
+  context 'with Monitor mocked' do
+    let(:monitor) { instance_double(Monitor) }
+
+    before do
+      allow(Monitor).to receive(:new).and_return(monitor)
+      allow(monitor).to receive(:synchronize).and_yield
+    end
+
+    it 'synchronizes concurrent updates' do
+      subject.clear
+      expect(monitor).to have_received(:synchronize)
+    end
+  end
 end

--- a/spec/unit/memoizable/memory/clear_spec.rb
+++ b/spec/unit/memoizable/memory/clear_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Memoizable::Memory, '#clear' do
+  subject { described_class.new(foo: 1) }
+
+  it 'returns itself' do
+    expect(subject.clear).to be_nil
+  end
+
+  it 'removes values' do
+    subject.clear
+    expect { subject[:foo] }.to raise_error(NameError)
+  end
+end

--- a/spec/unit/memoizable/memory/delete_spec.rb
+++ b/spec/unit/memoizable/memory/delete_spec.rb
@@ -7,4 +7,18 @@ describe Memoizable::Memory, '#delete' do
     expect(subject.delete(:foo)).to be_nil
     expect { subject[:foo] }.to raise_error(NameError)
   end
+
+  context 'with Monitor mocked' do
+    let(:monitor) { instance_double(Monitor) }
+
+    before do
+      allow(Monitor).to receive(:new).and_return(monitor)
+      allow(monitor).to receive(:synchronize).and_yield
+    end
+
+    it 'synchronizes concurrent updates' do
+      subject.delete(:foo)
+      expect(monitor).to have_received(:synchronize)
+    end
+  end
 end

--- a/spec/unit/memoizable/memory/delete_spec.rb
+++ b/spec/unit/memoizable/memory/delete_spec.rb
@@ -3,8 +3,12 @@ require 'spec_helper'
 describe Memoizable::Memory, '#delete' do
   subject { described_class.new(foo: 1) }
 
-  it 'removes a specific value' do
+  it 'returns nil' do
     expect(subject.delete(:foo)).to be_nil
+  end
+
+  it 'removes a specific value' do
+    subject.delete(:foo)
     expect { subject[:foo] }.to raise_error(NameError)
   end
 

--- a/spec/unit/memoizable/memory/delete_spec.rb
+++ b/spec/unit/memoizable/memory/delete_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Memoizable::Memory, '#delete' do
+  subject { described_class.new(foo: 1) }
+
+  it 'removes a specific value' do
+    expect(subject.delete(:foo)).to be_nil
+    expect { subject[:foo] }.to raise_error(NameError)
+  end
+end


### PR DESCRIPTION
This PR implements `Memory#delete` and `Memory#clear`.

We could make these methods behave just like `Hash#delete` and `Hash#clear`, but I'm not sure there's a use case for that. Instead, I opted to make both methods return void.