### PR TITLE
Add Memoizable::Memory #delete and #clear

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   base:
     name: Base steps
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Check Whitespace
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.1, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby-version: [3.1, 3.2, head]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
           echo 'Mutant not supported on ${{ matrix.ruby-version }}'
         fi
     - name: Upload coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success()
       with:
         name: coverage-${{ matrix.ruby-version }}

--- a/Gemfile
+++ b/Gemfile
@@ -8,13 +8,11 @@ group :test do
   gem 'rspec',     '~> 3.8', '>= 3.8.0'
   gem 'yardstick', '~> 0.9', '>= 0.9.9'
 
-  if RUBY_ENGINE.eql?('ruby') && RUBY_VERSION >= '2.7'
-    gem 'mutant',       '~> 0.11', '>= 0.11.22'
-    gem 'mutant-rspec', '~> 0.11', '>= 0.11.22'
-    gem 'simplecov',    '~> 0.22', '>= 0.22.0'
+  gem 'mutant',       '~> 0.12.4'
+  gem 'mutant-rspec', '~> 0.12.4'
+  gem 'simplecov',    '~> 0.22', '>= 0.22.0'
 
-    source 'https://oss:sxCL1o1navkPi2XnGB5WYBrhpY9iKIPL@gem.mutant.dev' do
-      gem 'mutant-license'
-    end
+  source 'https://oss:sxCL1o1navkPi2XnGB5WYBrhpY9iKIPL@gem.mutant.dev' do
+    gem 'mutant-license'
   end
 end

--- a/config/mutant.yml
+++ b/config/mutant.yml
@@ -1,4 +1,5 @@
 ---
+usage: opensource
 integration:
   name: rspec
 requires:

--- a/lib/memoizable/memory.rb
+++ b/lib/memoizable/memory.rb
@@ -85,6 +85,23 @@ module Memoizable
       end
     end
 
+    # Remove a specific value from memory
+    #
+    # @example
+    #   memory = Memoizable::Memory.new(foo: 1)
+    #   memory.delete(:foo)
+    #
+    # @param [Symbol] name
+    #
+    # @return [Object]
+    #
+    # @api public
+    def delete(name)
+      @monitor.synchronize do
+        @memory.delete(name)
+      end
+    end
+
     # A hook that allows Marshal to dump the object
     #
     # @example

--- a/lib/memoizable/memory.rb
+++ b/lib/memoizable/memory.rb
@@ -102,6 +102,22 @@ module Memoizable
       end
     end
 
+    # Remove all values from memory
+    #
+    # @example
+    #   memory = Memoizable::Memory.new(foo: 1)
+    #   memory.clear  # => memory
+    #
+    # @return [self]
+    #
+    # @api public
+    def clear
+      @monitor.synchronize do
+        @memory.clear
+      end
+      self
+    end
+
     # A hook that allows Marshal to dump the object
     #
     # @example

--- a/memoizable.gemspec
+++ b/memoizable.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.files            = %w[CONTRIBUTING.md LICENSE.md README.md memoizable.gemspec] + Dir['lib/**/*.rb']
   gem.extra_rdoc_files = Dir['**/*.md']
 
-  gem.required_ruby_version = '>= 2.1'
+  gem.required_ruby_version = '>= 3.1'
 end

--- a/spec/unit/memoizable/memory/clear_spec.rb
+++ b/spec/unit/memoizable/memory/clear_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Memoizable::Memory, '#clear' do
+  subject { described_class.new(foo: 1) }
+
+  shared_context '#clear behaviour' do
+    it 'returns self' do
+      expect(subject.clear).to be(subject)
+    end
+
+    it 'removes values' do
+      subject.clear
+
+      expect { subject[:foo] }.to raise_error(NameError)
+    end
+  end
+
+  context 'without Monitor mocked' do
+    include_examples '#clear behaviour'
+  end
+
+  context 'with Monitor mocked' do
+    let(:monitor) { instance_double(Monitor) }
+
+    before do
+      allow(Monitor).to receive_messages(new: monitor)
+      allow(monitor).to receive(:synchronize).and_yield
+    end
+
+    include_examples '#clear behaviour'
+
+    it 'synchronizes concurrent updates' do
+      subject.clear
+
+      expect(monitor).to have_received(:synchronize).once
+    end
+  end
+end

--- a/spec/unit/memoizable/memory/delete_spec.rb
+++ b/spec/unit/memoizable/memory/delete_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Memoizable::Memory, '#delete' do
+  subject { described_class.new(foo: 1) }
+
+  shared_context '#delete behaviour' do
+    it 'returns value at key' do
+      expect(subject.delete(:foo)).to be(1)
+    end
+
+    it 'removes key' do
+      expect(subject[:foo]).to be(1)
+
+      subject.delete(:foo)
+
+      expect { subject[:foo] }.to raise_error(NameError)
+    end
+  end
+
+  context 'without Monitor mocked' do
+    include_examples '#delete behaviour'
+  end
+
+  context 'with Monitor mocked' do
+    let(:monitor) { instance_double(Monitor) }
+
+    before do
+      allow(Monitor).to receive(:new).and_return(monitor)
+      allow(monitor).to receive(:synchronize).and_yield
+    end
+
+    include_examples '#delete behaviour'
+
+    it 'synchronizes concurrent updates' do
+      subject.delete(:foo)
+
+      expect(monitor).to have_received(:synchronize).once
+    end
+  end
+end


### PR DESCRIPTION
### Summary

- [x] [Fix build failures](https://github.com/dkubb/memoizable/pull/32/commits/e99dbc3f6ed615ff5d334dc445edda013f935392)
- [x] [Add Memoizable::Memory#delete](https://github.com/dkubb/memoizable/pull/32/commits/35ae521ba3abb0715a8f1190c52b01454ae92a48)
- [x] [Add Memoizable::Memory#clear](https://github.com/dkubb/memoizable/pull/32/commits/09231106229d6d2b7d9a688d369d114d92403d9e)

### Description

This branch of work is based off #31 by @rzane. All changes should be attributed to him, most changes were just rearranging the commit history and changing some of the specs/method signatures to match project conventions.
